### PR TITLE
Improve libxkbswitch.so discovery in unix systems

### DIFF
--- a/plugin/xkbswitch.vim
+++ b/plugin/xkbswitch.vim
@@ -21,7 +21,11 @@ if !exists('g:XkbSwitchLib')
         if empty($DISPLAY)
             finish
         endif
-        let g:XkbSwitchLib = '/usr/local/lib/libxkbswitch.so'
+        if filereadable('/usr/lib/libxkbswitch.so')
+            let g:XkbSwitchLib = '/usr/lib/libxkbswitch.so'
+        else
+            let g:XkbSwitchLib = '/usr/local/lib/libxkbswitch.so'
+        endif
     elseif has('win64')
         let g:XkbSwitchLib = $VIMRUNTIME.'/libxkbswitch64.dll'
     elseif has('win32')


### PR DESCRIPTION
Огромное вам спасибо за всю проделанную работу. Чудесный плагин! :smiley:

В некоторых случаях, _libxkbswitch.so_ может располагаться в `/usr/lib`, а не в `/usr/local/lib`. Например, когда _xkb-switch_ установлен из [AUR](https://aur.archlinux.org/packages/xkb-switch-git/) в ArchLinux.