### PR TITLE
Restore macos functionality after PR # 30

### DIFF
--- a/plugin/xkbswitch.vim
+++ b/plugin/xkbswitch.vim
@@ -16,7 +16,7 @@ let g:loaded_XkbSwitch = 1
 " prevent crashes of Vim due to xkb-switch (Github PR #30)
 " FIXME: this is too strict because another hypothetical keyboard layout
 "        switcher (that won't crash) can be used here
-if has('unix') && empty($DISPLAY)
+if !has('macunix') && has('unix') && empty($DISPLAY)
     let g:XkbSwitchEnabled = 0
 endif
 
@@ -437,7 +437,7 @@ fun! <SID>imappings_load()
                 endif
                 exe 'inoremap <silent> <buffer> <C-R>'.rim_key_tr.' <C-R>'.
                             \ rim_key
-            endfor 
+            endfor
         endif
     endfor
 endfun


### PR DESCRIPTION
After PR #30, vim-xkbswitch stopped to function on macos. There is no $DISPLAY env variable in mac, so after starting vim, `g:XkbSwitchEnabled` defaults to 0, despite it was set to 1 in user vimrc.
This PR skips $DISPLAY check on macos.
