### PR TITLE
Add support for leaderf

### DIFF
--- a/autoload/leaderf/xkbswitch.vim
+++ b/autoload/leaderf/xkbswitch.vim
@@ -1,0 +1,20 @@
+if !exists('g:XkbSwitchProgram')
+	if g:XkbSwitchLib =~# 'libxkbswitch'
+		let g:XkbSwitchProgram = 'xkb-switch'
+	else
+		let g:XkbSwitchProgram = 'g3kb-switch'
+	endif
+endif
+
+function! leaderf#xkbswitch#source(args) abort "{{{
+	return split(system(g:XkbSwitchProgram .. ' -l'))
+endfunction "}}}
+
+function! leaderf#xkbswitch#accept(line, args) abort "{{{
+	let b:xkb_ilayout = a:line
+endfunction "}}}
+
+function! leaderf#xkbswitch#bang_enter(orig_buf_nr, orig_cursor, args) abort "{{{
+	call search(get(g:, 'XkbSwitchNLayout', ''))
+	redraw
+endfunction "}}}

--- a/doc/xkbswitch.txt
+++ b/doc/xkbswitch.txt
@@ -23,7 +23,8 @@ Authors: Alexey Radkov; Dmitry Hrabrov a.k.a. DeXPeriX (softNO@SPAMdexp.in)
         5.4 Disable for specific filetypes ...: |xkbswitch-filetype-disable|
         5.5 Enable in runtime ................: |xkbswitch-runtime-enable|
     6. Custom keyboard layout switching rules.: |xkbswitch-plugins|
-    7. Troubleshooting .......................: |xkbswitch-issues|
+    7. Integration with other plugins ........: |xkbswitch-integration|
+    8. Troubleshooting .......................: |xkbswitch-issues|
     A. Change History ........................: |xkbswitch-changes|
 
 ==============================================================================
@@ -503,8 +504,24 @@ comments areas, but in the mdict rule we do not care about leaving areas
 'mdictOriginal' and 'mdictTranslated' and only care about entering them.
 
 ==============================================================================
+                                            *xkbswitch-integration*
+7. Integration with other plugins~
+
+------------------------------------------------------------------------------
+                                            *xkbswitch-leaderf*
+7.1 LeaderF~
+
+The command `Leaderf xkbswitch` can popup a window to switch input method.
+
+The introduction of `Leaderf` can be found in
+https://github.com/Yggdroot/LeaderF
+
+A test vimrc can be found in
+https://github.com/lyokha/vim-xkbswitch/pull/45#issue-493491212 .
+
+==============================================================================
                                             *xkbswitch-issues*
-7. Troubleshooting~
+8. Troubleshooting~
 
   - Some characters from alternative keyboard layouts may fail to enter or
     behave in strange ways for certain filetypes. For example in Russian

--- a/plugin/xkbswitch.vim
+++ b/plugin/xkbswitch.vim
@@ -810,3 +810,23 @@ if g:XkbSwitchEnabled
     call <SID>enable_xkb_switch(1)
 endif
 
+if !exists('g:leaderf_loaded')
+    finish
+endif
+
+if !exists('g:Lf_Extensions')
+    let g:Lf_Extensions = {}
+endif
+
+let g:Lf_Extensions.xkbswitch = {
+            \ 'source': 'leaderf#xkbswitch#source',
+            \ 'accept': 'leaderf#xkbswitch#accept',
+            \ 'bang_enter': 'leaderf#xkbswitch#bang_enter',
+            \ 'highlights_def': {
+            \ 'Lf_hl_xkbswitchTitle': '.*',
+            \ },
+            \ 'highlights_cmd': [
+            \ 'hi link Lf_hl_xkbswitchTitle Title',
+            \ ],
+            \ }
+


### PR DESCRIPTION
```{.vim}
" File: $XDG_CONFIG_HOME/nvim/test.vim
" OS: linux v5.4.13
" Vi: nvim v0.4.3
" Py: cpython v3.6.10
" Term: guake v3.7.0
set runtimepath=$VIMRUNTIME,$GITHUBWORKSPACE/Yggdroot/LeaderF,$GITHUBWORKSPACE/bling/vim-airline,$GITHUBWORKSPACE/Freed-Wu/vim-xkbswitch
let g:Lf_WindowPosition = 'popup'
let g:XkbSwitchLib = '/usr/local/lib/libg3kbswitch.so'
let g:XkbSwitchEnabled = 1
let g:XkbSwitchNLayout = 'us'
inoremap <C-]> <C-o>:Leaderf xkbswitch<CR>
" vi -u $XDG_CONFIG_HOME/nvim/test.vim
```
press `i`
![Screenshot from 2020-09-26 13-08-31](https://user-images.githubusercontent.com/32936898/94330701-70a4a780-fff9-11ea-8923-6ed642f69124.png)

Now user press `<C-]>` can get 
![Screenshot from 2020-09-26 13-06-40](https://user-images.githubusercontent.com/32936898/94330666-26bbc180-fff9-11ea-9638-22480f106d5d.png)

![Screenshot from 2020-09-26 13-07-30](https://user-images.githubusercontent.com/32936898/94330681-42bf6300-fff9-11ea-9d5b-3ce053cc93c0.png)
![Screenshot from 2020-09-26 13-07-49](https://user-images.githubusercontent.com/32936898/94330688-4ce16180-fff9-11ea-91d3-6c6c2862bc81.png)

if someone has many different inputmethod, it will be more easy to switch. 

and if someone don't have installed <https://github.com/Yggdroot/LeaderF>,
```{.vim}
if !exists('g:leaderf_loaded')
    finish
endif
.......
```
will make nothing happened. So Leaderf must sourced before xkbswitch.