### PR TITLE
test one more path for libg3kbswitch.so

### DIFF
--- a/plugin/xkbswitch.vim
+++ b/plugin/xkbswitch.vim
@@ -37,6 +37,8 @@ if !exists('g:XkbSwitchLib') && $XDG_SESSION_DESKTOP ==# 'gnome'
         let g:XkbSwitchLib = '/usr/lib/libg3kbswitch.so'
     elseif filereadable('/usr/lib64/libg3kbswitch.so')
         let g:XkbSwitchLib = '/usr/lib64/libg3kbswitch.so'
+    elseif filereadable('/usr/lib64/g3kb-switch/libg3kbswitch.so')
+        let g:XkbSwitchLib = '/usr/lib64/g3kb-switch/libg3kbswitch.so'
     endif
 endif
 


### PR DESCRIPTION
I packaged g3kb-switch in fedora.
As it's an unversioned so lib, that is not linked against, I want to place it in the subdir